### PR TITLE
Add IGWN frontend public key

### DIFF
--- a/oauth2/certs.json
+++ b/oauth2/certs.json
@@ -25,6 +25,15 @@
             "use": "sig",
             "x": "yst6hluWbSpAsqZzE97IXqScLxKHt-1a7AeCQM4t0uY=",
             "y": "TqWqVtRSWk_CqSMndKP9AfxKW7wu6akwcOZ1LBF3lDU="
+        },
+        {
+            "alg": "ES256",
+            "crv": "P-256",
+            "kid": "60fb",
+            "kty": "EC",
+            "use": "sig",
+            "x": "s_ql9pW7qhgMzC0hCWT2xKNZvRgh6hvPj6N7UZLI3k0=",
+            "y": "k_DcFDIDxQiofHNqXX_8UiRKrrBm0ezn3W8Qdtl_do0="
         }
     ]
 }


### PR DESCRIPTION
The IGWN (LIGO/VIRGO/KAGRA) frontend will sign and send scitokens along with pilot jobs so that CEs can validate that the payload was issued from the claimed frontend. The issuer claim for these scitokens will be set to https://scitokens.org/ligo.