### PR TITLE
INF-1463 Add RSA-based key for IGWN glideins

### DIFF
--- a/oauth2/certs.json
+++ b/oauth2/certs.json
@@ -3,6 +3,14 @@
         {
             "alg": "RS256",
             "e": "AQAB",
+            "kid": "8086",
+            "kty": "RSA",
+            "n": "vCeo1GsfC51Sm6pNvj0wIhNQcHF8uMjzMuTWt4HABn1LINaXbytKAePve_EZUVAfQIxEQ0v7bjT1IIBJoBWjgpfEEFoTBkVOY1CPuhKh9ExPaoinpiWJLDpblQ8rRJgQy7wk54Heur7WCm-3px3XDlmdsdN10HNrxlGRUJYvoe_FM2pi49Ad1qnejhPCoPHQFbPn5S9uYFi1SPw6rarwmOitIxlnsCmECAzLds5V0BOi1dBJKbrVN74m34VkhlgOm1daAKfH11SWVTi2E_pI6yEJqKN1W0YECKQymtL2uMsvqcxxo2ePU4jfU_LCyN0Ox0PY_PDgHc_PDQ6innpM0Q==",
+            "use": "sig"
+        },
+        {
+            "alg": "RS256",
+            "e": "AQAB",
             "kid": "c013",
             "kty": "RSA",
             "n": "qMsZ5mS92pQWKX_YtmaVPl0NmDTGeb0qsJ0TZ0Tkr1Am6j5BWJ0FtbE4LKGB5F01ISIvmJBwP3FpkCXA2z2vP6FqudIGiiFShvq13x22t2en5PKek1-d8ynFnPp7ksYw33jszcOM7_BqFNsZ-ouWQuqifoKHueQ0SyS830CyMUUePLoL9yQy3RuqP2SraPQgZQCxzpX89pLGRFn5c8QsH4IMUzN00bC0Kn0ADOQLBXTsQ3PJ1gu_nAvlwAz_eJPL91PFxXqDJTvkvsDrAT1gS1nZPzr3PfLXEKmUu23E9HU_0Lh5MWZV6vN96BUK6F80bEFBkfseWa5az8R81UauDQ==",


### PR DESCRIPTION
The ARC CE REST interface is not able to process ECC-signed scitokens. The IGWN glideinWMS frontend will be updated to generate scitokens using an RSA private key that can be verified using the attached public key (`8086`).